### PR TITLE
opengraph: use response.content instead of response.text

### DIFF
--- a/app/utils/opengraph.py
+++ b/app/utils/opengraph.py
@@ -144,7 +144,7 @@ async def _og_meta_from_url(url: str) -> OpenGraphMeta | None:
         return None
 
     try:
-        return scrap_og_meta(url, resp.text)
+        return scrap_og_meta(url, resp.content)
     except TimeoutError:
         logger.info(f"Timed out when scraping OG meta for {url}")
         return None


### PR DESCRIPTION
requests uses HTTP headers for decoding response content, while some
webpages indicate their encodings in the meta header.

Pass response.content, which is the raw content and not decoded by the
requets library, to BeautifulSoup, make charset detection done by BS4,
which makes use of the meta headers.
